### PR TITLE
[univ-oauth] 소셜 로그인 기능 초기 구현 및 템플릿 수정

### DIFF
--- a/univ-domain/build.gradle
+++ b/univ-domain/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 }

--- a/univ-domain/src/main/java/com/hallym/user/config/SecurityConfig.java
+++ b/univ-domain/src/main/java/com/hallym/user/config/SecurityConfig.java
@@ -19,7 +19,7 @@ public class SecurityConfig {
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .loginPage("/login")  // 커스텀 로그인 페이지
-                        .defaultSuccessUrl("/")  // 성공 후 리디렉션
+                        .defaultSuccessUrl("/welcome", true)     // 성공 후 리디렉션
                 );
 
         return http.build();

--- a/univ-domain/src/main/java/com/hallym/user/config/SecurityConfig.java
+++ b/univ-domain/src/main/java/com/hallym/user/config/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.hallym.user.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/oauth2/**", "/login/**", "/css/**", "/js/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .loginPage("/login")  // 커스텀 로그인 페이지
+                        .defaultSuccessUrl("/")  // 성공 후 리디렉션
+                );
+
+        return http.build();
+    }
+}

--- a/univ-domain/src/main/java/com/hallym/user/controller/UserController.java
+++ b/univ-domain/src/main/java/com/hallym/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.hallym.user.model.Role;
 import com.hallym.user.service.UserService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -77,6 +78,29 @@ public class UserController {
     public String logoutPost(HttpSession session) {
         session.invalidate();
         return "redirect:/login";
+    }
+
+    @GetMapping("/welcome")
+    public String welcomePage(Model model,
+                              @SessionAttribute(value = "user", required = false) Object sessionUser,
+                              @AuthenticationPrincipal org.springframework.security.oauth2.core.user.OAuth2User oauthUser) {
+
+        if (sessionUser != null) {
+            // 일반 로그인 사용자 (세션 기반)
+            model.addAttribute("userType", "session");
+            model.addAttribute("email", ((com.hallym.user.entity.User) sessionUser).getEmail());
+            model.addAttribute("nickname", ((com.hallym.user.entity.User) sessionUser).getNickname());
+        } else if (oauthUser != null) {
+            // 소셜 로그인 사용자 (Spring Security 기반)
+            model.addAttribute("userType", "oauth");
+            model.addAttribute("email", oauthUser.getAttribute("email"));
+            model.addAttribute("nickname", oauthUser.getAttribute("name"));
+        } else {
+            // 로그인 안 된 상태 → 로그인 페이지로 리다이렉트
+            return "redirect:/login";
+        }
+
+        return "welcome"; // templates/welcome.html 렌더링
     }
 
 }

--- a/univ-domain/src/main/resources/templates/login.html
+++ b/univ-domain/src/main/resources/templates/login.html
@@ -65,6 +65,28 @@
             background-color: #0d47a1;
         }
 
+        .social-login {
+            margin-top: 1.5rem;
+            text-align: center;
+        }
+
+        .social-login a {
+            display: inline-block;
+            margin: 0.5rem;
+            padding: 0.7rem 1.5rem;
+            background-color: #f4f4f4;
+            color: #333;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            text-decoration: none;
+            font-weight: bold;
+            transition: 0.3s;
+        }
+
+        .social-login a:hover {
+            background-color: #e0e0e0;
+        }
+
         .switch-link {
             text-align: center;
             margin-top: 1rem;
@@ -90,6 +112,13 @@
         </label>
         <button type="submit">로그인</button>
     </form>
+
+    <div class="social-login">
+        <p>소셜 계정으로 로그인:</p>
+        <a href="/oauth2/authorization/google">Google</a>
+        <a href="/oauth2/authorization/kakao">Kakao</a>
+        <a href="/oauth2/authorization/naver">Naver</a>
+    </div>
 
     <div class="switch-link">
         계정이 없으신가요?

--- a/univ-domain/src/main/resources/templates/welcome.html
+++ b/univ-domain/src/main/resources/templates/welcome.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>회원가입 완료</title>
+    <title>환영합니다</title>
     <style>
         body {
             font-family: 'Segoe UI', sans-serif;
@@ -12,6 +12,7 @@
             height: 100vh;
             margin: 0;
         }
+
         .box {
             background: white;
             padding: 2.5rem 3rem;
@@ -20,15 +21,18 @@
             text-align: center;
             max-width: 400px;
         }
+
         h1 {
             color: #1565c0;
             margin-bottom: 1rem;
         }
+
         p {
             color: #555;
             font-size: 1.1rem;
-            margin-bottom: 1rem;
+            margin-bottom: 0.5rem;
         }
+
         .login-button {
             display: inline-block;
             margin-top: 1rem;
@@ -41,6 +45,7 @@
             text-decoration: none;
             transition: 0.3s;
         }
+
         .login-button:hover {
             background-color: #0d47a1;
         }
@@ -49,9 +54,13 @@
 <body>
 <div class="box">
     <h1 th:text="'환영합니다, ' + ${nickname} + '님!'">환영합니다!</h1>
-    <p>🎉 유니브 스터디에 오신 것을 진심으로 환영합니다!</p>
-    <p>지금 바로 스터디를 시작해보세요.</p>
-    <a href="/login" class="login-button">로그인하러 가기</a>
+
+    <p th:if="${userType} == 'session'">일반 로그인 사용자로 로그인되었습니다.</p>
+    <p th:if="${userType} == 'oauth'">소셜 로그인 사용자로 로그인되었습니다.</p>
+
+    <p th:text="'이메일: ' + ${email}">이메일 표시</p>
+
+    <a href="/logout" class="login-button">로그아웃</a>
 </div>
 </body>
 </html>

--- a/univ-oauth/build.gradle
+++ b/univ-oauth/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    implementation project(':univ-security')
+    implementation project(':univ-domain')
 
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/univ-oauth/src/main/java/com/hallym/controller/OAuthUserController.java
+++ b/univ-oauth/src/main/java/com/hallym/controller/OAuthUserController.java
@@ -1,0 +1,16 @@
+package com.hallym.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+public class OAuthUserController {
+
+    @GetMapping("/oauth/success")
+    public String oauthSuccess(@AuthenticationPrincipal OAuth2User oauthUser, Model model) {
+        String nickname = oauthUser.getAttribute("nickname");
+        model.addAttribute("nickname", nickname);
+        return "welcome";
+    }
+}

--- a/univ-oauth/src/main/java/com/hallym/service/CustomOAuth2UserService.java
+++ b/univ-oauth/src/main/java/com/hallym/service/CustomOAuth2UserService.java
@@ -1,0 +1,54 @@
+package com.hallym.service;
+
+import com.hallym.user.entity.User;
+import com.hallym.user.model.Provider;
+
+
+import com.hallym.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserService userService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
+        OAuth2User oauthUser = super.loadUser(request);
+        String providerName = request.getClientRegistration().getRegistrationId();
+        OAuth2UserInfo userInfo = extractOAuth2UserInfo(providerName, oauthUser.getAttributes());
+
+        User user = userService.getOrCreateSocialUser(
+                userInfo.getId(),
+                Provider.valueOf(providerName.toUpperCase()),
+                userInfo.getEmail(),
+                userInfo.getNickname()
+        );
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(user.getRole().name())),
+                oauthUser.getAttributes(),
+                "id"
+        );
+    }
+
+    private OAuth2UserInfo extractOAuth2UserInfo(String provider, Map<String, Object> attributes) {
+        return switch (provider) {
+            case "kakao" -> new KakaoOAuth2UserInfo(attributes);
+            case "naver" -> new NaverOAuth2UserInfo(attributes);
+            case "google" -> new GoogleOAuth2UserInfo(attributes);
+            default -> throw new IllegalArgumentException("지원하지 않는 OAuth 제공자입니다.");
+        };
+    }
+}

--- a/univ-oauth/src/main/java/com/hallym/service/GoogleOAuth2UserInfo.java
+++ b/univ-oauth/src/main/java/com/hallym/service/GoogleOAuth2UserInfo.java
@@ -1,0 +1,26 @@
+package com.hallym.service;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
+    private final Map<String, Object> attributes;
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getId() {
+        return attributes.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+}

--- a/univ-oauth/src/main/java/com/hallym/service/KakaoOAuth2UserInfo.java
+++ b/univ-oauth/src/main/java/com/hallym/service/KakaoOAuth2UserInfo.java
@@ -1,0 +1,30 @@
+package com.hallym.service;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
+    private final Map<String, Object> attributes;
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        return (String) kakaoAccount.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        return (String) profile.get("nickname");
+    }
+
+}

--- a/univ-oauth/src/main/java/com/hallym/service/NaverOAuth2UserInfo.java
+++ b/univ-oauth/src/main/java/com/hallym/service/NaverOAuth2UserInfo.java
@@ -1,0 +1,30 @@
+package com.hallym.service;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo implements OAuth2UserInfo {
+    private final Map<String, Object> attributes;
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getId() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return (String) response.get("id");
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return (String) response.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return (String) response.get("name");
+    }
+
+}

--- a/univ-oauth/src/main/java/com/hallym/service/OAuth2UserInfo.java
+++ b/univ-oauth/src/main/java/com/hallym/service/OAuth2UserInfo.java
@@ -1,0 +1,8 @@
+package com.hallym.service;
+
+
+public interface OAuth2UserInfo {
+    String getId();
+    String getEmail();
+    String getNickname();
+}


### PR DESCRIPTION
## 작업 내용

![스크린샷 2025-06-04 오후 4 31 38](https://github.com/user-attachments/assets/806d48cb-c5b7-4bbc-9508-af19967fc31a)
- 소셜 로그인 초기 구현: Google, Kakao, Naver 소셜 로그인 기능을 위한 클래스 및 템플릿 수정
- OAuth2UserInfo 인터페이스와 각 소셜 로그인 제공자별 구현 클래스 작성

## 특이사항
SecurityConfig 클래스에서 소셜 로그인 경로를 허용하도록 설정
login.html 템플릿에 소셜 로그인 버튼 추가